### PR TITLE
detect callback argument in task definition

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,14 @@ var retrieveArguments = require('retrieve-arguments'), minimist = require('minim
   stringify = require('node-stringify'), debug = require('debug')('gulp-param');
 
 module.exports = function (gulp, processArgv, callbackFunctionName) {
+  // @nrser we're going to use this twice now so just set the default here
+  if (!callbackFunctionName) {
+    callbackFunctionName = 'callback';
+  }
+  
   var parsedCmdArguments = minimist(processArgv);
+  // @nrser `originalCallbackFunction` will be `undefined` if the task
+  // definition does not take the callback function as an argument.
   var prepareArgumentsArray = function (functionArguments, originalCallbackFunction) {
     var arguments = [];
     debug('prepare argument base on function arguments (%s) and parsed commandline (%s)',
@@ -12,7 +19,10 @@ module.exports = function (gulp, processArgv, callbackFunctionName) {
       var functionArgument = functionArguments[i], value = parsedCmdArguments[functionArgument];
       if (value) {
         arguments.push(value);
-      } else if (functionArgument === (callbackFunctionName || "callback")) {
+      } else if (functionArgument === callbackFunctionName) {
+        if (typeof originalCallbackFunction === 'undefined') {
+          throw new Error("THIS SHOULD NEVER HAPPEN");
+        }
         arguments.push(originalCallbackFunction);
       } else {arguments.push(undefined);}
     }
@@ -26,10 +36,32 @@ module.exports = function (gulp, processArgv, callbackFunctionName) {
       taskDependencies = undefined;
     }
     taskDefinition = taskDefinition || function () {};
+    
+    var wrappedTaskFunction;
+    
+    // @nrser need to see if `taskDefinition` takes the callback argument
+    // so we know if the wrapped function should or not
+    //
+    // https://github.com/stoeffel/gulp-param/issues/30
+    // 
+    var taskDefinitionArgs = retrieveArguments(taskDefinition);
+    
+    if (taskDefinitionArgs.indexOf(callbackFunctionName) === -1) {
+      // @nrser `taskDefinition` does not take the callback argument, so the
+      // wrapped function should not accept a callback, causing gulp to treat
+      // it as synchronous
+      wrappedTaskFunction = function () {
+        return taskDefinition.apply(gulp, prepareArgumentsArray(taskDefinitionArgs));
+      };
+    } else {
+      // @nrser `taskDefinition` takes the callback argument, so the wrapped
+      // function should accept a callback, causing gulp to treat it as 
+      // asynchronous
+      wrappedTaskFunction = function (originalCallbackFunction) {
+        return taskDefinition.apply(gulp, prepareArgumentsArray(taskDefinitionArgs, originalCallbackFunction));
+      };
+    }
 
-    var wrappedTaskFunction = function (originalCallbackFunction) {
-      return taskDefinition.apply(gulp, prepareArgumentsArray(retrieveArguments(taskDefinition), originalCallbackFunction));
-    };
     return origTask.call(gulp, taskName, taskDependencies || [], wrappedTaskFunction);
   };
 


### PR DESCRIPTION
here's the patch i hacked together addressing #30. didn't write any tests for this stuff but the suite still passes. solved my problem and about all the time i have to put into it at the moment.

by the way, this is just a bug fix off v1.0.3 and should be merged against that to make 1.0.4 if you like... i see that you guys have kept going quite a bit since then but i wanted to work of the stable release... wasn't sure how to indicate that in the PR.