### PR TITLE
Gulp 4 upgrade

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,16 @@ module.exports = function (gulp, processArgv, callbackName) {
         retrieveArguments
       )(task);
     };
-    return gulp.task.call(gulp, taskName, taskDependencies || [], wrappedTaskFunction);
+
+    var wrappedFunctionWithDependencies = (function (taskDependencies, wrappedTaskFunction) {
+      if (Array.isArray(taskDependencies)) {
+        return gulp.series(taskDependencies, wrappedTaskFunction);
+      } else {
+        return wrappedTaskFunction;
+      }
+    })(taskDependencies, wrappedTaskFunction);
+
+    return gulp.task.call(gulp, taskName, wrappedFunctionWithDependencies);
   };
   return R.merge(R.clone(gulp), {task: wrappedTask});
 };

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "chai": "^3.4.1",
     "codecov": "^1.0.1",
-    "gulp": "^3.9.0",
+    "gulp": "^4.0.2",
     "gulp-uglify": "^2.0.0",
     "istanbul": "^0.4.2",
     "mocha": "^3.2.0",


### PR DESCRIPTION
Straightforward implementation to support Gulp 4.

Fixes the error 'AssertionError: Task function must be specified'.

Inspiration: https://www.liquidlight.co.uk/blog/how-do-i-update-to-gulp-4/